### PR TITLE
Update datapath to 4‑bit money handling

### DIFF
--- a/D_count/D_count.vhd
+++ b/D_count/D_count.vhd
@@ -7,12 +7,12 @@ entity D_count is
         clk   : in  STD_LOGIC;
         reset : in  STD_LOGIC;
         coin  : in  STD_LOGIC; -- pulso quando uma unidade de moeda é inserida
-        D     : out STD_LOGIC_VECTOR(4 downto 0)
+        D     : out STD_LOGIC_VECTOR(3 downto 0)
     );
 end D_count;
 
 architecture Behavioral of D_count is
-    signal count : unsigned(4 downto 0) := (others => '0');
+    signal count : unsigned(3 downto 0) := (others => '0');
 begin
     process(clk, reset)
     begin

--- a/D_count/tb_D_count.vhd
+++ b/D_count/tb_D_count.vhd
@@ -13,7 +13,7 @@ architecture behavior of tb_D_count is
             clk   : in  STD_LOGIC;
             reset : in  STD_LOGIC;
             coin  : in  STD_LOGIC;
-            D     : out STD_LOGIC_VECTOR(4 downto 0)
+            D     : out STD_LOGIC_VECTOR(3 downto 0)
         );
     end component;
 
@@ -21,7 +21,7 @@ architecture behavior of tb_D_count is
     signal clk   : STD_LOGIC := '0';
     signal reset : STD_LOGIC := '0';
     signal coin  : STD_LOGIC := '0';
-    signal D     : STD_LOGIC_VECTOR(4 downto 0);
+    signal D     : STD_LOGIC_VECTOR(3 downto 0);
 
     -- Clock de 10 ns (100 MHz)
     constant clk_period : time := 10 ns;

--- a/Maquina/Maquina.vhd
+++ b/Maquina/Maquina.vhd
@@ -12,7 +12,7 @@ entity Maquina is
         refri   : in  STD_LOGIC; -- 0: Guaraná, 1: Coca-Cola
         btn_qtd : in  STD_LOGIC; -- botão que incrementa quantidade
         dinheiro: in  STD_LOGIC; -- pulso simulando nota inserida
-        troco   : out STD_LOGIC_VECTOR(8 downto 0);
+        troco   : out STD_LOGIC_VECTOR(3 downto 0);
         lucro   : out STD_LOGIC_VECTOR(8 downto 0)
     );
 end Maquina;

--- a/Maquina/tb_Maquina.vhd
+++ b/Maquina/tb_Maquina.vhd
@@ -18,7 +18,7 @@ architecture behavior of tb_Maquina is
             refri    : in  STD_LOGIC;
             btn_qtd  : in  STD_LOGIC;
             dinheiro : in  STD_LOGIC;
-            troco    : out STD_LOGIC_VECTOR(8 downto 0);
+            troco    : out STD_LOGIC_VECTOR(3 downto 0);
             lucro    : out STD_LOGIC_VECTOR(8 downto 0)
         );
     end component;
@@ -32,7 +32,7 @@ architecture behavior of tb_Maquina is
     signal refri    : STD_LOGIC := '1'; -- Coca-Cola
     signal btn_qtd  : STD_LOGIC := '0';
     signal dinheiro : STD_LOGIC := '0';
-    signal troco    : STD_LOGIC_VECTOR(8 downto 0);
+    signal troco    : STD_LOGIC_VECTOR(3 downto 0);
     signal lucro    : STD_LOGIC_VECTOR(8 downto 0);
 
     constant clk_period : time := 10 ns;

--- a/Multiplicador/Multiplicador.vhd
+++ b/Multiplicador/Multiplicador.vhd
@@ -6,7 +6,7 @@ entity Multiplicador is
     Port (
         preco_unitario : in STD_LOGIC_VECTOR(3 downto 0); -- P1 ou P2
         quantidade     : in STD_LOGIC_VECTOR(1 downto 0); -- Q_count
-        resultado      : out STD_LOGIC_VECTOR(5 downto 0) -- P = preço total
+        resultado      : out STD_LOGIC_VECTOR(3 downto 0) -- P = preço total
     );
 end Multiplicador;
 
@@ -16,10 +16,16 @@ begin
         variable preco_int : unsigned(3 downto 0);
         variable qtd_int   : unsigned(1 downto 0);
         variable prod      : unsigned(5 downto 0);
+        variable prod_sat  : unsigned(3 downto 0);
     begin
         preco_int := unsigned(preco_unitario);
         qtd_int   := unsigned(quantidade);
         prod := preco_int * qtd_int;
-        resultado <= std_logic_vector(prod);
+        if prod > 15 then
+            prod_sat := to_unsigned(15, 4);
+        else
+            prod_sat := resize(prod, 4);
+        end if;
+        resultado <= std_logic_vector(prod_sat);
     end process;
 end Behavioral;

--- a/Multiplicador/tb_Multiplicador.vhd
+++ b/Multiplicador/tb_Multiplicador.vhd
@@ -12,14 +12,14 @@ architecture behavior of tb_Multiplicador is
         Port (
             preco_unitario : in  STD_LOGIC_VECTOR(3 downto 0);
             quantidade     : in  STD_LOGIC_VECTOR(1 downto 0);
-            resultado      : out STD_LOGIC_VECTOR(5 downto 0)
+            resultado      : out STD_LOGIC_VECTOR(3 downto 0)
         );
     end component;
 
     -- Sinais de estímulo
     signal preco_unitario : STD_LOGIC_VECTOR(3 downto 0) := (others => '0');
     signal quantidade     : STD_LOGIC_VECTOR(1 downto 0) := (others => '0');
-    signal resultado      : STD_LOGIC_VECTOR(5 downto 0);
+    signal resultado      : STD_LOGIC_VECTOR(3 downto 0);
 
 begin
 

--- a/T_count/T_count.vhd
+++ b/T_count/T_count.vhd
@@ -4,19 +4,19 @@ use IEEE.NUMERIC_STD.ALL;
 
 entity T_count is
     Port (
-        D_count : in STD_LOGIC_VECTOR(8 downto 0); -- valor inserido
-        P_count : in STD_LOGIC_VECTOR(6 downto 0); -- preço total
-        T       : out STD_LOGIC_VECTOR(8 downto 0) -- troco calculado
+        D_count : in STD_LOGIC_VECTOR(3 downto 0); -- valor inserido
+        P_count : in STD_LOGIC_VECTOR(3 downto 0); -- preço total
+        T       : out STD_LOGIC_VECTOR(3 downto 0) -- troco calculado
     );
 end T_count;
 
 architecture Behavioral of T_count is
-    signal D_u  : unsigned(8 downto 0);
-    signal P_u  : unsigned(8 downto 0);
-    signal T_u  : unsigned(8 downto 0);
+    signal D_u  : unsigned(3 downto 0);
+    signal P_u  : unsigned(3 downto 0);
+    signal T_u  : unsigned(3 downto 0);
 begin
     D_u <= unsigned(D_count);
-    P_u <= ("00" & unsigned(P_count)); -- extensão para 9 bits
+    P_u <= unsigned(P_count);
     T_u <= D_u - P_u;
 
     T <= std_logic_vector(T_u);

--- a/T_count/tb_T_count.vhd
+++ b/T_count/tb_T_count.vhd
@@ -10,16 +10,16 @@ architecture behavior of tb_T_count is
     -- Componente a ser testado
     component T_count
         Port (
-            D_count : in  STD_LOGIC_VECTOR(8 downto 0);
-            P_count : in  STD_LOGIC_VECTOR(6 downto 0);
-            T       : out STD_LOGIC_VECTOR(8 downto 0)
+            D_count : in  STD_LOGIC_VECTOR(3 downto 0);
+            P_count : in  STD_LOGIC_VECTOR(3 downto 0);
+            T       : out STD_LOGIC_VECTOR(3 downto 0)
         );
     end component;
 
     -- Sinais
-    signal D_count : STD_LOGIC_VECTOR(8 downto 0) := (others => '0');
-    signal P_count : STD_LOGIC_VECTOR(6 downto 0) := (others => '0');
-    signal T       : STD_LOGIC_VECTOR(8 downto 0);
+    signal D_count : STD_LOGIC_VECTOR(3 downto 0) := (others => '0');
+    signal P_count : STD_LOGIC_VECTOR(3 downto 0) := (others => '0');
+    signal T       : STD_LOGIC_VECTOR(3 downto 0);
 
 begin
 
@@ -34,29 +34,24 @@ begin
     -- Processo de estímulo
     stim_proc: process
     begin
-        -- D = 20, P = 6 → T = 14
-        D_count <= "000010100";  -- 20
-        P_count <= "0000110";    -- 6
+        -- D = 10, P = 6 → T = 4
+        D_count <= "1010";  -- 10
+        P_count <= "0110";  -- 6
         wait for 10 ns;
 
-        -- D = 50, P = 50 → T = 0
-        D_count <= "000110010";  -- 50
-        P_count <= "0110010";    -- 50
+        -- D = 15, P = 15 → T = 0
+        D_count <= "1111";
+        P_count <= "1111";
         wait for 10 ns;
 
-        -- D = 100, P = 25 → T = 75
-        D_count <= "001100100";  -- 100
-        P_count <= "0011001";    -- 25
-        wait for 10 ns;
-
-        -- D = 127, P = 0 → T = 127
-        D_count <= "011111111";
-        P_count <= "0000000";
+        -- D = 8, P = 3 → T = 5
+        D_count <= "1000";
+        P_count <= "0011";
         wait for 10 ns;
 
         -- D = 0, P = 0 → T = 0
-        D_count <= "000000000";
-        P_count <= "0000000";
+        D_count <= "0000";
+        P_count <= "0000";
         wait for 10 ns;
 
         wait;

--- a/datapath/datapath.vhd
+++ b/datapath/datapath.vhd
@@ -12,19 +12,19 @@ entity Datapath is
         preco2 : in  STD_LOGIC_VECTOR(3 downto 0);
         inc_q  : in  STD_LOGIC; -- incrementa quantidade
         venda  : in  STD_LOGIC; -- finaliza venda
-        troco  : out STD_LOGIC_VECTOR(8 downto 0);
+        troco  : out STD_LOGIC_VECTOR(3 downto 0);
         lucro  : out STD_LOGIC_VECTOR(8 downto 0)
     );
 end Datapath;
 
 architecture Structural of Datapath is
-    signal D_val   : STD_LOGIC_VECTOR(4 downto 0);
+    signal D_val   : STD_LOGIC_VECTOR(3 downto 0);
     signal Q_val   : STD_LOGIC_VECTOR(1 downto 0);
     signal preco_s : STD_LOGIC_VECTOR(3 downto 0);
-    signal P_temp  : STD_LOGIC_VECTOR(5 downto 0);
+    signal P_temp  : STD_LOGIC_VECTOR(3 downto 0);
     signal P_cnt   : STD_LOGIC_VECTOR(6 downto 0);
-    signal D_ext   : STD_LOGIC_VECTOR(8 downto 0);
-    signal troco_s : STD_LOGIC_VECTOR(8 downto 0);
+    signal D_ext   : STD_LOGIC_VECTOR(3 downto 0);
+    signal troco_s : STD_LOGIC_VECTOR(3 downto 0);
     signal lucro_s : STD_LOGIC_VECTOR(8 downto 0);
 begin
     D_counter: entity work.D_count
@@ -58,13 +58,13 @@ begin
             resultado      => P_temp
         );
 
-    P_cnt <= '0' & P_temp; -- extensao para 7 bits
-    D_ext <= "0000" & D_val; -- extensao para 9 bits
+    P_cnt <= "000" & P_temp; -- extensao para 7 bits
+    D_ext <= D_val; -- sem extensao, 4 bits
 
     CalculaTroco: entity work.T_count
         port map(
             D_count => D_ext,
-            P_count => P_cnt,
+            P_count => P_temp,
             T       => troco_s
         );
 

--- a/datapath/tb_datapath.vhd
+++ b/datapath/tb_datapath.vhd
@@ -18,7 +18,7 @@ architecture behavior of tb_Datapath is
             preco2  : in  STD_LOGIC_VECTOR(3 downto 0);
             inc_q   : in  STD_LOGIC;
             venda   : in  STD_LOGIC;
-            troco   : out STD_LOGIC_VECTOR(8 downto 0);
+            troco   : out STD_LOGIC_VECTOR(3 downto 0);
             lucro   : out STD_LOGIC_VECTOR(8 downto 0)
         );
     end component;
@@ -32,7 +32,7 @@ architecture behavior of tb_Datapath is
     signal preco2  : STD_LOGIC_VECTOR(3 downto 0) := "0010"; -- R$2,00
     signal inc_q   : STD_LOGIC := '0';
     signal venda   : STD_LOGIC := '0';
-    signal troco   : STD_LOGIC_VECTOR(8 downto 0);
+    signal troco   : STD_LOGIC_VECTOR(3 downto 0);
     signal lucro   : STD_LOGIC_VECTOR(8 downto 0);
 
     constant clk_period : time := 10 ns;


### PR DESCRIPTION
## Summary
- shrink `D_count` counter and output to 4 bits
- update datapath and top level for 4‑bit change handling
- reduce `T_count` and `Multiplicador` widths
- saturate multiplication result to 15
- fix all related test benches

## Testing
- `ghdl -a D_count/D_count.vhd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865abcb9984832c95c261ac47fc6ab2