### PR TITLE
Update FSM to hold in SelecionaQtd until beverage chosen

### DIFF
--- a/Controladora/Controladora.vhd
+++ b/Controladora/Controladora.vhd
@@ -65,13 +65,13 @@ begin
             when SelecionaQtd =>
                 if btn_qtd = '1' then
                     inc_q_s <= '1';
+                elsif refri = '0' or refri = '1' then
                     proximo_estado <= SelecionaRefri;
                 end if;
 
             when SelecionaRefri =>
-                if refri = '0' or refri = '1' then
-                    proximo_estado <= AguardaPagamento;
-                end if;
+                -- Avança imediatamente para pagamento ao receber a escolha
+                proximo_estado <= AguardaPagamento;
 
             when AguardaPagamento =>
                 if dinheiro = '1' then

--- a/Controladora/tb_Controladora.vhd
+++ b/Controladora/tb_Controladora.vhd
@@ -78,7 +78,9 @@ begin
         -- Etapa 1: inserção do copo
         I <= '1'; wait for 10 ns;
 
-        -- Etapa 2: seleção da quantidade
+        -- Etapa 2: seleção da quantidade (duas escolhas)
+        btn_qtd <= '1'; wait for 10 ns;
+        btn_qtd <= '0'; wait for 10 ns;
         btn_qtd <= '1'; wait for 10 ns;
         btn_qtd <= '0'; wait for 10 ns;
 

--- a/Maquina/tb_Maquina.vhd
+++ b/Maquina/tb_Maquina.vhd
@@ -30,7 +30,7 @@ architecture behavior of tb_Maquina is
     signal I        : STD_LOGIC := '0';
     signal preco1   : STD_LOGIC_VECTOR(3 downto 0) := "0011"; -- R$3,00 por 300 mL (Coca)
     signal preco2   : STD_LOGIC_VECTOR(3 downto 0) := "0010"; -- R$2,00 por 300 mL (Guaraná)
-    signal refri    : STD_LOGIC := '1'; -- Coca-Cola
+    signal refri    : STD_LOGIC := '0'; -- sem seleção inicial
     signal btn_qtd  : STD_LOGIC := '0';
     signal dinheiro : STD_LOGIC := '0';
     signal valor    : STD_LOGIC_VECTOR(4 downto 0) := (others => '0');
@@ -87,7 +87,8 @@ begin
         btn_qtd <= '1'; wait for 10 ns;
         btn_qtd <= '0'; wait for 10 ns;
 
-        -- Seleciona refrigerante Coca-Cola (refri = '1') já está setado
+        -- Seleciona refrigerante Coca-Cola
+        refri <= '1'; wait for 10 ns;
 
         -- Insere nota de R$10
         valor <= "01010";
@@ -101,14 +102,15 @@ begin
         I <= '0'; wait for 20 ns;
         I <= '1'; wait for 20 ns;
 
-        refri <= '0'; -- Guaraná
+        btn_qtd <= '1'; wait for 10 ns;
+        btn_qtd <= '0'; wait for 10 ns;
+        btn_qtd <= '1'; wait for 10 ns;
+        btn_qtd <= '0'; wait for 10 ns;
+        btn_qtd <= '1'; wait for 10 ns;
+        btn_qtd <= '0'; wait for 10 ns;
 
-        btn_qtd <= '1'; wait for 10 ns;
-        btn_qtd <= '0'; wait for 10 ns;
-        btn_qtd <= '1'; wait for 10 ns;
-        btn_qtd <= '0'; wait for 10 ns;
-        btn_qtd <= '1'; wait for 10 ns;
-        btn_qtd <= '0'; wait for 10 ns;
+        -- Seleciona refrigerante Guaraná
+        refri <= '0'; wait for 10 ns;
 
         valor <= "01010";
         dinheiro <= '1'; wait for 10 ns;


### PR DESCRIPTION
## Summary
- keep `SelecionaQtd` active when `btn_qtd` is pressed
- move to next state only after choosing the beverage
- adapt control testbench to increment quantity twice before selecting
- delay beverage choice in machine testbench

## Testing
- `ghdl -a Q_count/Q_count.vhd Q_count/tb_Q_count.vhd && ghdl -e tb_Q_count && ghdl -r tb_Q_count --stop-time=200ns` *(fails: ghdl not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b151066e8832cb694f4e44dd8a318