### PR TITLE
Use Subtrator module for change calculation

### DIFF
--- a/Subtrator/Subtrator.vhd
+++ b/Subtrator/Subtrator.vhd
@@ -1,16 +1,16 @@
 library IEEE;
 use IEEE.STD_LOGIC_1164.ALL;
-use IEEE.STD_LOGIC_UNSIGNED.ALL;
+use IEEE.NUMERIC_STD.ALL;
 
 entity Subtrator is
     Port (
-        D : in STD_LOGIC_VECTOR(4 downto 0); -- Dinheiro inserido (5 bits)
-        P : in STD_LOGIC_VECTOR(4 downto 0); -- Preço (ajustado para 5 bits para compatibilidade)
-        T : out STD_LOGIC_VECTOR(4 downto 0) -- Troco
+        D : in STD_LOGIC_VECTOR(8 downto 0); -- Dinheiro inserido (9 bits)
+        P : in STD_LOGIC_VECTOR(8 downto 0); -- Preço (9 bits)
+        T : out STD_LOGIC_VECTOR(8 downto 0) -- Troco
     );
 end Subtrator;
 
 architecture Behavioral of Subtrator is
 begin
-    T <= D - P;
+    T <= std_logic_vector(unsigned(D) - unsigned(P));
 end Behavioral;

--- a/Subtrator/tb_Subtrator.vhd
+++ b/Subtrator/tb_Subtrator.vhd
@@ -1,6 +1,6 @@
 library IEEE;
 use IEEE.STD_LOGIC_1164.ALL;
-use IEEE.STD_LOGIC_UNSIGNED.ALL;
+use IEEE.NUMERIC_STD.ALL;
 
 entity tb_Subtrator is
 end tb_Subtrator;
@@ -10,16 +10,16 @@ architecture behavior of tb_Subtrator is
     -- Componente a ser testado
     component Subtrator
         Port (
-            D : in  STD_LOGIC_VECTOR(4 downto 0); -- Dinheiro inserido
-            P : in  STD_LOGIC_VECTOR(4 downto 0); -- Preço
-            T : out STD_LOGIC_VECTOR(4 downto 0)  -- Troco
+            D : in  STD_LOGIC_VECTOR(8 downto 0); -- Dinheiro inserido
+            P : in  STD_LOGIC_VECTOR(8 downto 0); -- Preço
+            T : out STD_LOGIC_VECTOR(8 downto 0)  -- Troco
         );
     end component;
 
     -- Sinais
-    signal D : STD_LOGIC_VECTOR(4 downto 0) := (others => '0');
-    signal P : STD_LOGIC_VECTOR(4 downto 0) := (others => '0');
-    signal T : STD_LOGIC_VECTOR(4 downto 0);
+    signal D : STD_LOGIC_VECTOR(8 downto 0) := (others => '0');
+    signal P : STD_LOGIC_VECTOR(8 downto 0) := (others => '0');
+    signal T : STD_LOGIC_VECTOR(8 downto 0);
 
 begin
 
@@ -34,29 +34,29 @@ begin
     -- Processo de estímulo
     stim_proc: process
     begin
-        -- D = 10, P = 6 → T = 4
-        D <= "01010"; -- 10
-        P <= "00110"; -- 6
+        -- D = 20, P = 6 → T = 14
+        D <= "000010100"; -- 20
+        P <= "000000110"; -- 6
         wait for 10 ns;
 
-        -- D = 8, P = 8 → T = 0
-        D <= "01000"; -- 8
-        P <= "01000"; -- 8
+        -- D = 50, P = 50 → T = 0
+        D <= "000110010"; -- 50
+        P <= "000110010"; -- 50
         wait for 10 ns;
 
-        -- D = 5, P = 2 → T = 3
-        D <= "00101"; -- 5
-        P <= "00010"; -- 2
+        -- D = 100, P = 25 → T = 75
+        D <= "001100100"; -- 100
+        P <= "000011001"; -- 25
         wait for 10 ns;
 
-        -- D = 31, P = 1 → T = 30 (máximo valor)
-        D <= "11111"; -- 31
-        P <= "00001"; -- 1
+        -- D = 127, P = 0 → T = 127
+        D <= "011111111"; -- 127
+        P <= "000000000"; -- 0
         wait for 10 ns;
 
         -- D = 0, P = 0 → T = 0
-        D <= "00000";
-        P <= "00000";
+        D <= "000000000";
+        P <= "000000000";
         wait for 10 ns;
 
         wait;

--- a/datapath/datapath.vhd
+++ b/datapath/datapath.vhd
@@ -74,11 +74,11 @@ begin
     D_ext <= D_val;
 
     -- Subtrator para cálculo do troco
-    CalculaTroco: entity work.T_count
+    CalculaTroco: entity work.Subtrator
         port map (
-            D_count => D_ext,
-            P_count => P_ext,
-            T       => troco_s
+            D => D_ext,
+            P => P_ext,
+            T => troco_s
         );
 
     -- Somador para acumular lucro


### PR DESCRIPTION
## Summary
- update Subtrator to work with 9-bit values using `numeric_std`
- update Subtrator test bench for new width
- switch datapath to instantiate `Subtrator` instead of `T_count`

## Testing
- `ghdl -a Subtrator/Subtrator.vhd` *(fails: command not found)*
- `ghdl -e tb_Subtrator` *(fails: command not found)*
- `ghdl -r tb_Subtrator --stop-time=1us` *(fails: command not found)*
- `ghdl -a datapath/datapath.vhd` *(fails: command not found)*
- `ghdl -e tb_Datapath` *(fails: command not found)*
- `ghdl -r tb_Datapath --stop-time=1us` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b26ac008c832c9bf74a1229f1aedb